### PR TITLE
Fixes abnormal power consumption on UMI

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -248,6 +248,7 @@ scripts/config --file out/.config \
     -e MIUI_ZRAM_MEMORY_TRACKING \
     -d CONFIG_MODULE_SIG_SHA512 \
     -d CONFIG_MODULE_SIG_HASH \
+    -e MI_SCHED \
     -e MI_FRAGMENTION \
 
 make $MAKE_ARGS -j$(nproc)

--- a/drivers/scsi/ufs/ufs-qcom.c
+++ b/drivers/scsi/ufs/ufs-qcom.c
@@ -2057,9 +2057,13 @@ __setup("androidboot.bootdevice=", get_android_boot_dev);
  */
 static void ufs_qcom_parse_lpm(struct ufs_qcom_host *host)
 {
+#if IS_ENABLED(CONFIG_BOARD_UMI) || IS_ENABLED(CONFIG_BOARD_THYME)
+	host->disable_lpm = false;
+#else
 	struct device_node *node = host->hba->dev->of_node;
 
 	host->disable_lpm = of_property_read_bool(node, "qcom,disable-lpm");
+#endif
 	if (host->disable_lpm)
 		pr_info("%s: will disable all LPM modes\n", __func__);
 }


### PR DESCRIPTION
Abnormal power consumption has long existed in all rebase kernels because we ignored the following changes from cmi-r-oss

- This is what Xiaomi did on cmi-r-oss [1][2].
- Disable LPM modes results in abnormal power consumption on UMI.
- Guard for THYME too as it has the same node in device tree.

Ref:
[1]: https://github.com/MiCode/Xiaomi_Kernel_OpenSource/blob/cmi-r-oss/drivers/scsi/ufs/ufs-qcom.c#L2033-L2038 [2]: https://github.com/MiCode/kernel_devicetree/blob/cmi-r-oss/qcom/umi-sm8250.dtsi#L11

* Thanks @TheVoyager0777 for found out this particular change

Change-Id: I78d1fd5936cdd871a2ca2626d4a6e0d335a96c83