### PR TITLE
修改ccache的二进制文件位置

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ fi
 export CCACHE_DIR="$HOME/.cache/ccache_mikernel" 
 export CC="ccache gcc"
 export CXX="ccache g++"
-export PATH="/usr/lib/ccache:$PATH"
+export PATH="$(which ccache):$PATH"
 echo "CCACHE_DIR: [$CCACHE_DIR]"
 
 


### PR DESCRIPTION
`ccache`的二进制文件不一定在`/usr/lib/`目录下，还有可能在`/usr/bin/`目录下，使用`which`命令获取`ccache`的二进制文件的真正位置